### PR TITLE
leshan: return -1 instead of None when get() encounters errors

### DIFF
--- a/leshan.py
+++ b/leshan.py
@@ -80,7 +80,7 @@ def get(url, raw=False):
         try:
             payload = json.loads(response.content)
         except:
-            return None
+            return -1
         if raw:
             return payload
         else:
@@ -89,7 +89,7 @@ def get(url, raw=False):
                     return payload['content']['value']
     else:
         logging.error(response)
-        return None
+        return -1
 
 def put(url, data):
     response = requests.put(url, data=json.dumps(data), headers=headers)
@@ -156,7 +156,7 @@ def update(ua, thread_count):
             logging.info('executing the firmware update')
         if ua.download_status == 4:
             logging.error('unknown status')
-        if ua.download_status is None:
+        if ua.download_status < 0:
             logging.error('no longer found')
         # TODO check timeout?
         time.sleep(thread_wait)


### PR DESCRIPTION
This fix is sort of hacky as we normally return whatever the payload is and that could be anything.  But for our purposes we're using get() to return status codes.

This fixes an error path spew that complains when we check the returned "None" for < 1.
 