### PR TITLE
leshan: correct UpdateAction "update_status" variable usage

### DIFF
--- a/leshan.py
+++ b/leshan.py
@@ -221,7 +221,7 @@ def run(client, url, hostname, port, monitor, device, max_threads):
         elif ua.result:
             logging.info('[%s] update SUCCESS (%d seconds)', ua.client, timediff.seconds)
         else:
-            logging.info('[%s] update FAILED(%d) (%d seconds)', ua.client, ua.update_status, timediff.seconds)
+            logging.info('[%s] update FAILED(%d) (%d seconds)', ua.client, ua.update_result, timediff.seconds)
             result = 1
     timediff = datetime.datetime.now() - start_time
     logging.info('%d update(s) attempted which took %d seconds total', count, timediff.seconds)


### PR DESCRIPTION
There is no member variable named "update_status" in UpdateAction.
This is supposed to be "update_result".

Fixes error spew when an update fails.

Signed-off-by: Michael Scott <michael@opensourcefoundries.com>